### PR TITLE
Add truncation and batching for text classification

### DIFF
--- a/spacy_transformers_pipeline/tests/test_pipeline_components.py
+++ b/spacy_transformers_pipeline/tests/test_pipeline_components.py
@@ -39,7 +39,9 @@ def test_ext_tok_clf(aggregation_strategy, annotate, n_process):
     doc = nlp(" ")
 
     for doc in nlp.pipe(
-        ["a", "b", " ", "c", "", "aaaaabbbbccc bbbccc cccc"], n_process=n_process
+        ["a", "b", " ", "c", "", "aaaaabbbbccc bbbccc cccc", "a bc def " * 500],
+        batch_size=2,
+        n_process=n_process,
     ):
         _check_tok_cls_annotation(doc, annotate)
 
@@ -81,9 +83,10 @@ def test_ext_txt_clf(n_process):
 
     doc = nlp("")
     doc = nlp(" ")
+    doc = nlp("a bc def " * 1000)
 
     for doc in nlp.pipe(
-        ["a", "b", " ", "c", "", "aaaaabbbbccc bbbccc cccc", "f"],
+        ["a", "b", " ", "c", "", "aaabbbccc bbbccc cccc", "f", "a b c " * 500],
         batch_size=2,
         n_process=n_process,
     ):


### PR DESCRIPTION
* Truncate (silently) for text classification
* Use `batch_size` to batch texts for text classification (token classification treats a list input as a single batch, text classification does not)
* Test with `batch_size` for text and token classification