### PR TITLE
Improve error handling and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ for doc in nlp.pipe(texts, batch_size=256):
     do_something(doc)
 ```
 
+If the component runs into an error processing a batch (e.g. on an empty text),
+`nlp.pipe` will back off to processing each text individually. If it runs into
+an error on an individual text, a warning is shown and the doc is returned
+without additional annotation.
+
 Switch to GPU:
 
 ```python

--- a/spacy_huggingface_pipelines/tests/test_pipeline_components.py
+++ b/spacy_huggingface_pipelines/tests/test_pipeline_components.py
@@ -11,8 +11,12 @@ torch.set_num_threads(1)
 @pytest.mark.parametrize("aggregation_strategy", ("simple", "first", "average", "max"))
 @pytest.mark.parametrize("annotate", ("ents", "spans", "tag"))
 @pytest.mark.parametrize("n_process", (1, 2))
-@pytest.mark.filterwarnings("ignore:Unable to process, skipping annotation for doc ' ':UserWarning")
-@pytest.mark.filterwarnings("ignore:Unable to process, skipping annotation for doc '':UserWarning")
+@pytest.mark.filterwarnings(
+    "ignore:Unable to process, skipping annotation for doc ' ':UserWarning"
+)
+@pytest.mark.filterwarnings(
+    "ignore:Unable to process, skipping annotation for doc '':UserWarning"
+)
 @pytest.mark.filterwarnings("ignore:Unable to process texts as batch:UserWarning")
 def test_hf_token_pipe(aggregation_strategy, annotate, n_process):
     if (

--- a/spacy_huggingface_pipelines/tests/test_pipeline_components.py
+++ b/spacy_huggingface_pipelines/tests/test_pipeline_components.py
@@ -11,7 +11,9 @@ torch.set_num_threads(1)
 @pytest.mark.parametrize("aggregation_strategy", ("simple", "first", "average", "max"))
 @pytest.mark.parametrize("annotate", ("ents", "spans", "tag"))
 @pytest.mark.parametrize("n_process", (1, 2))
-@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.filterwarnings("ignore:Unable to process, skipping annotation for doc ' ':UserWarning")
+@pytest.mark.filterwarnings("ignore:Unable to process, skipping annotation for doc '':UserWarning")
+@pytest.mark.filterwarnings("ignore:Unable to process texts as batch:UserWarning")
 def test_hf_token_pipe(aggregation_strategy, annotate, n_process):
     if (
         n_process > 1
@@ -32,14 +34,14 @@ def test_hf_token_pipe(aggregation_strategy, annotate, n_process):
     )
     doc = nlp("a")
     _check_tok_cls_annotation(doc, annotate)
-    doc = nlp("a bc def " * 1000)
+    doc = nlp("a b c d e f " * 1000)
     _check_tok_cls_annotation(doc, annotate)
 
     doc = nlp("")
     doc = nlp(" ")
 
     for doc in nlp.pipe(
-        ["a", "b", " ", "c", "", "aaaaabbbbccc bbbccc cccc", "a bc def " * 500],
+        ["a", "b", " ", "c", "", "a b c d e a b c d e", "a b c d e f " * 250],
         batch_size=2,
         n_process=n_process,
     ):
@@ -62,7 +64,6 @@ def _check_tok_cls_annotation(doc, annotate):
 
 
 @pytest.mark.parametrize("n_process", (1, 2))
-@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_hf_text_pipe(n_process):
     if (
         n_process > 1

--- a/spacy_huggingface_pipelines/text_classification.py
+++ b/spacy_huggingface_pipelines/text_classification.py
@@ -72,11 +72,17 @@ class HfTextPipe(Pipe):
         return next(self.pipe([doc]))
 
     def pipe(self, stream: Iterable[Doc], *, batch_size: int = 128) -> Iterator[Doc]:
-        for docs in util.minibatch(stream, size=batch_size):
-            outputs = self._get_annotations(docs, batch_size=batch_size)
-            for doc, output in zip(docs, outputs):
-                doc.cats.update({a["label"]: a["score"] for a in output})
-                yield doc
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="You seem to be using the pipelines sequentially on GPU",
+                category=UserWarning,
+            )
+            for docs in util.minibatch(stream, size=batch_size):
+                outputs = self._get_annotations(docs, batch_size=batch_size)
+                for doc, output in zip(docs, outputs):
+                    doc.cats.update({a["label"]: a["score"] for a in output})
+                    yield doc
 
     def _get_annotations(self, docs: List[Doc], batch_size) -> List[List[dict]]:
         if len(docs) > 1:
@@ -93,7 +99,9 @@ class HfTextPipe(Pipe):
             try:
                 outputs.append(self.hf_pipeline(doc.text, top_k=None))
             except Exception:
-                text_excerpt = doc.text if len(doc.text) < 100 else doc.text[:100] + "..."
+                text_excerpt = (
+                    doc.text if len(doc.text) < 100 else doc.text[:100] + "..."
+                )
                 warnings.warn(
                     f"Unable to process, skipping annotation for doc '{text_excerpt}'"
                 )

--- a/spacy_huggingface_pipelines/token_classification.py
+++ b/spacy_huggingface_pipelines/token_classification.py
@@ -120,7 +120,11 @@ class HfTokenPipe(Pipe):
                             output_spans.append(output_span)
                             prev_ann_end = ann["end"]
                         else:
-                            text_excerpt = doc.text if len(doc.text) < 100 else doc.text[:100] + "..."
+                            text_excerpt = (
+                                doc.text
+                                if len(doc.text) < 100
+                                else doc.text[:100] + "..."
+                            )
                             warnings.warn(
                                 f"Skipping annotation, {ann} is overlapping or can't be aligned for doc '{text_excerpt}'"
                             )
@@ -131,7 +135,14 @@ class HfTokenPipe(Pipe):
         with warnings.catch_warnings():
             # the PipelineChunkIterator does not report its length correctly,
             # leading to many spurious warnings from torch
-            warnings.filterwarnings("ignore", message="Length of IterableDataset", category=UserWarning)
+            warnings.filterwarnings(
+                "ignore", message="Length of IterableDataset", category=UserWarning
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message="You seem to be using the pipelines sequentially on GPU",
+                category=UserWarning,
+            )
             if len(docs) > 1:
                 try:
                     return self.hf_pipeline([doc.text for doc in docs])
@@ -144,7 +155,9 @@ class HfTokenPipe(Pipe):
                 try:
                     outputs.append(self.hf_pipeline(doc.text))
                 except Exception:
-                    text_excerpt = doc.text if len(doc.text) < 100 else doc.text[:100] + "..."
+                    text_excerpt = (
+                        doc.text if len(doc.text) < 100 else doc.text[:100] + "..."
+                    )
                     warnings.warn(
                         f"Unable to process, skipping annotation for doc '{text_excerpt}'"
                     )

--- a/spacy_huggingface_pipelines/token_classification.py
+++ b/spacy_huggingface_pipelines/token_classification.py
@@ -120,33 +120,36 @@ class HfTokenPipe(Pipe):
                             output_spans.append(output_span)
                             prev_ann_end = ann["end"]
                         else:
+                            text_excerpt = doc.text if len(doc.text) < 100 else doc.text[:100] + "..."
                             warnings.warn(
-                                f"Skipping annotation, {ann} is overlapping or can't be aligned for span {repr(doc.text)}"
+                                f"Skipping annotation, {ann} is overlapping or can't be aligned for doc '{text_excerpt}'"
                             )
                 self._set_annotation_from_spans(doc, output_spans)
                 yield doc
 
     def _get_annotations(self, docs: List[Doc]) -> List[List[dict]]:
-        # TODO: warn when truncating? (I'm not sure you can detect this
-        # easily through the current pipeline API)
-        try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=UserWarning)
-                return self.hf_pipeline([doc.text for doc in docs])
-        except Exception:
-            # TODO: better UX
-            pass
-        outputs = []
-        for doc in docs:
-            try:
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore", category=UserWarning)
+        with warnings.catch_warnings():
+            # the PipelineChunkIterator does not report its length correctly,
+            # leading to many spurious warnings from torch
+            warnings.filterwarnings("ignore", message="Length of IterableDataset", category=UserWarning)
+            if len(docs) > 1:
+                try:
+                    return self.hf_pipeline([doc.text for doc in docs])
+                except Exception:
+                    warnings.warn(
+                        "Unable to process texts as batch, backing off to processing texts individually"
+                    )
+            outputs = []
+            for doc in docs:
+                try:
                     outputs.append(self.hf_pipeline(doc.text))
-            except Exception:
-                # TODO: better UX
-                warnings.warn(f"Unable to process, skipping doc {repr(doc.text)}")
-                outputs.append([])
-        return outputs
+                except Exception:
+                    text_excerpt = doc.text if len(doc.text) < 100 else doc.text[:100] + "..."
+                    warnings.warn(
+                        f"Unable to process, skipping annotation for doc '{text_excerpt}'"
+                    )
+                    outputs.append([])
+            return outputs
 
     def _set_annotation_from_spans(self, doc: Doc, spans: List[Span]) -> Doc:
         if self.annotate == "ents":


### PR DESCRIPTION
These components back off from batch to single processing in order to handle problematic docs that lead to errors for the transformers `Pipeline` processing (known issues are with "empty" docs like `""` or `" "` but there could potentially be other issues depending on the model).

The warnings are a bit noisy, but I'd rather not crash on or skip entire batches containing problematic texts, and if there is no indication, then it's not clear to users why there can be huge speed differences between individual batches.