### PR TITLE
Add scores for spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ print(doc.ents)
 # (Sarah, London)
 ```
 
-2. Save named entity annotation as `Doc.spans[spans_key]`:
+2. Save named entity annotation as `Doc.spans[spans_key]` and scores as
+   `Doc.spans[spans_key].attrs["scores"]`:
 
 ```python
 import spacy
@@ -132,6 +133,8 @@ nlp.add_pipe(
 doc = nlp("My name is Sarah and I live in London")
 print(doc.spans["bert-base-ner"])
 # [Sarah, London]
+print(doc.spans["bert-base-ner"].attrs["scores"])
+# [0.99854773, 0.9996215]
 ```
 
 3. Save fine-grained tags as `Token.tag`:

--- a/spacy_huggingface_pipelines/tests/test_pipeline_components.py
+++ b/spacy_huggingface_pipelines/tests/test_pipeline_components.py
@@ -97,3 +97,26 @@ def test_hf_text_pipe(n_process):
     ):
         assert len(doc.cats) > 0
         assert all(l.startswith("LABEL_") for l in doc.cats)
+
+
+@pytest.mark.parametrize("n_process", (1, 2))
+def test_scores_are_added_as_extentions_to_spans(n_process):
+    if (
+        n_process > 1
+        and isinstance(get_torch_default_device().index, int)
+        and get_torch_default_device().index >= 0
+    ):
+        return
+    nlp = spacy.blank("xx")
+    nlp.add_pipe(
+        "hf_token_pipe",
+        config={
+            "model": "hf-internal-testing/tiny-random-BertForTokenClassification",
+            "annotate": "spans",
+            "annotate_spans_key": "bert-base-ner",
+        },
+    )
+    doc = nlp("a")
+    assert doc.spans["bert-base-ner"][0].has_extension("score")
+    assert doc.spans["b"][0]._.score > 0
+

--- a/spacy_huggingface_pipelines/tests/test_pipeline_components.py
+++ b/spacy_huggingface_pipelines/tests/test_pipeline_components.py
@@ -118,5 +118,5 @@ def test_scores_are_added_as_extentions_to_spans(n_process):
     )
     doc = nlp("a")
     assert doc.spans["bert-base-ner"][0].has_extension("score")
-    assert doc.spans["b"][0]._.score > 0
+    assert doc.spans["bert-base-ner"][0]._.score > 0
 

--- a/spacy_huggingface_pipelines/tests/test_pipeline_components.py
+++ b/spacy_huggingface_pipelines/tests/test_pipeline_components.py
@@ -7,6 +7,10 @@ import spacy
 
 torch.set_num_threads(1)
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The 'warn' method is deprecated.*:DeprecationWarning"
+)
+
 
 @pytest.mark.parametrize("aggregation_strategy", ("simple", "first", "average", "max"))
 @pytest.mark.parametrize("annotate", ("ents", "spans", "tag"))
@@ -63,6 +67,7 @@ def _check_tok_cls_annotation(doc, annotate):
                 assert ent.label_.startswith("LABEL_")
         elif annotate == "spans":
             assert len(doc.spans["tiny"]) > 0
+            assert len(doc.spans["tiny"]) == len(doc.spans["tiny"].attrs["scores"])
             for span in doc.spans["tiny"]:
                 assert span.label_.startswith("LABEL_")
 

--- a/spacy_huggingface_pipelines/tests/test_pipeline_components.py
+++ b/spacy_huggingface_pipelines/tests/test_pipeline_components.py
@@ -118,5 +118,5 @@ def test_scores_are_added_as_extentions_to_spans(n_process):
     )
     doc = nlp("a")
     assert doc.spans["bert-base-ner"][0].has_extension("score")
-    assert doc.spans["bert-base-ner"][0]._.score > 0
+    assert doc.spans["b"][0]._.score > 0
 

--- a/spacy_huggingface_pipelines/tests/test_pipeline_components.py
+++ b/spacy_huggingface_pipelines/tests/test_pipeline_components.py
@@ -97,26 +97,3 @@ def test_hf_text_pipe(n_process):
     ):
         assert len(doc.cats) > 0
         assert all(l.startswith("LABEL_") for l in doc.cats)
-
-
-@pytest.mark.parametrize("n_process", (1, 2))
-def test_scores_are_added_as_extentions_to_spans(n_process):
-    if (
-        n_process > 1
-        and isinstance(get_torch_default_device().index, int)
-        and get_torch_default_device().index >= 0
-    ):
-        return
-    nlp = spacy.blank("xx")
-    nlp.add_pipe(
-        "hf_token_pipe",
-        config={
-            "model": "hf-internal-testing/tiny-random-BertForTokenClassification",
-            "annotate": "spans",
-            "annotate_spans_key": "bert-base-ner",
-        },
-    )
-    doc = nlp("a")
-    assert doc.spans["bert-base-ner"][0].has_extension("score")
-    assert doc.spans["b"][0]._.score > 0
-

--- a/spacy_huggingface_pipelines/token_classification.py
+++ b/spacy_huggingface_pipelines/token_classification.py
@@ -113,8 +113,6 @@ class HFTokenPipe(Pipe):
                             label=ann["entity_group"],
                             alignment_mode=self.alignment_mode,
                         )
-                        if output_span is not None:
-                            output_span._.score = ann["score"]
                         if (
                             output_span is not None
                             and output_span.start_char >= prev_ann_end

--- a/spacy_huggingface_pipelines/token_classification.py
+++ b/spacy_huggingface_pipelines/token_classification.py
@@ -113,6 +113,8 @@ class HFTokenPipe(Pipe):
                             label=ann["entity_group"],
                             alignment_mode=self.alignment_mode,
                         )
+                        if output_span is not None:
+                            output_span._.score = ann["score"]
                         if (
                             output_span is not None
                             and output_span.start_char >= prev_ann_end

--- a/spacy_huggingface_pipelines/token_classification.py
+++ b/spacy_huggingface_pipelines/token_classification.py
@@ -167,7 +167,7 @@ class HFTokenPipe(Pipe):
 
     def _set_annotation_from_spans(self, doc: Doc, spans: SpanGroup) -> Doc:
         if self.annotate == "ents":
-            doc.set_ents(spans)
+            doc.set_ents(list(spans))
         elif self.annotate == "spans":
             doc.spans[self.annotate_spans_key] = spans
         elif self.annotate == "tag":

--- a/spacy_huggingface_pipelines/token_classification.py
+++ b/spacy_huggingface_pipelines/token_classification.py
@@ -95,6 +95,8 @@ class HFTokenPipe(Pipe):
                 )
         self.alignment_mode = alignment_mode
         self.scorer = scorer
+        Span.set_extension("score", default=0.0, force=True)
+        
 
     def __call__(self, doc: Doc) -> Doc:
         return next(self.pipe([doc]))

--- a/spacy_huggingface_pipelines/token_classification.py
+++ b/spacy_huggingface_pipelines/token_classification.py
@@ -95,8 +95,6 @@ class HFTokenPipe(Pipe):
                 )
         self.alignment_mode = alignment_mode
         self.scorer = scorer
-        Span.set_extension("score", default=0.0, force=True)
-        
 
     def __call__(self, doc: Doc) -> Doc:
         return next(self.pipe([doc]))


### PR DESCRIPTION
This PR introduces the model's confidence score ("score") into a `Span` extension (as a `Span` does not have a field for confidence values / scores / probabilities). 
Example:

```python
nlp = spacy.blank("xx")
nlp.add_pipe(
    "hf_token_pipe",
    config={
        "model": "hf-internal-testing/tiny-random-BertForTokenClassification",
        "annotate": "spans",
        "annotate_spans_key": "bert-base-ner",
    },
)
doc = nlp("a")
print(doc.spans["bert-base-ner"][0]._.score)
```

This would allow the spaCy pipeline to expose the HF model's confidence and not just the tokens' locations and labels.